### PR TITLE
:bug: Bugfixes for 429 HTTP errors

### DIFF
--- a/components/workbook/asyncQuiz/index.tsx
+++ b/components/workbook/asyncQuiz/index.tsx
@@ -7,7 +7,8 @@ import { ethers } from "ethers";
 
 export const fetchBalance = async () => {
     try {
-        const provider = ethers.getDefaultProvider();
+        const provider = new ethers.providers.EtherscanProvider("homestead", process.env.API_KEY);
+        provider.pollingInterval = 4000;
         const daiAddress = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
         const daiAbi = ["function balanceOf(address) view returns (uint256)"];
         const daiContract = new ethers.Contract(daiAddress, daiAbi, provider);


### PR DESCRIPTION
Patched the 429 HTTP errors which were triggered in the asyncQuiz.tsx code. 
This was done through the use of a custom API key - which requires the use of environment variables (see `process.env.API_KEY`). 
Let me know if this works for you!